### PR TITLE
Add payment statuses filter to decide if new entries should be created

### DIFF
--- a/class-woocommerce.php
+++ b/class-woocommerce.php
@@ -341,7 +341,7 @@ if ( class_exists( 'GFForms' ) ) {
 		 * @return array
 		 */
 		public function get_entry_meta( $entry_meta, $form_id ) {
-			if ( $this->is_woocommerce_orders_integration_enabled( $form_id ) || rgpost( 'woocommerce_orders_integration_enabled' ) ) {
+			if ( $this->can_create_entry_for_order( $form_id ) || rgpost( 'woocommerce_orders_integration_enabled' ) ) {
 				$entry_meta['workflow_woocommerce_order_id'] = array(
 					'label'             => esc_html__( 'WooCommerce Order ID', 'gravityflowwoocommerce' ),
 					'is_numeric'        => true,
@@ -364,7 +364,7 @@ if ( class_exists( 'GFForms' ) ) {
 		 *
 		 * @return int True if integration is enabled. False otherwise.
 		 */
-		public function is_woocommerce_orders_integration_enabled( $form_id ) {
+		public function can_create_entry_for_order( $form_id ) {
 			$form     = GFAPI::get_form( $form_id );
 			$settings = $this->get_form_settings( $form );
 
@@ -806,7 +806,7 @@ if ( class_exists( 'GFForms' ) ) {
 			// get forms with WooCommerce integration.
 			$form_ids = RGFormsModel::get_form_ids();
 			foreach ( $form_ids as $key => $form_id ) {
-				if ( ! $this->is_woocommerce_orders_integration_enabled( $form_id ) || ! $this->is_woocommerce_payment_status_enabled( $form_id, $order_id ) || in_array( $form_id, $forms_has_entry, true ) || $this->has_wcgf_entries( $form_id, $order_id ) ) {
+				if ( ! $this->can_create_entry_for_order( $form_id ) || ! $this->is_woocommerce_payment_status_enabled( $form_id, $order_id ) || in_array( $form_id, $forms_has_entry, true ) || $this->has_wcgf_entries( $form_id, $order_id ) ) {
 					unset( $form_ids[ $key ] );
 				}
 			}
@@ -856,7 +856,7 @@ if ( class_exists( 'GFForms' ) ) {
 			foreach ( $entry_ids as $entry_id ) {
 				$entry = GFAPI::get_entry( $entry_id );
 				// Don't update entry if the WooCommerce integration is disabled.
-				if ( is_wp_error( $entry ) || ! $this->is_woocommerce_orders_integration_enabled( $entry['form_id'] ) ) {
+				if ( is_wp_error( $entry ) || ! $this->can_create_entry_for_order( $entry['form_id'] ) ) {
 					continue;
 				}
 
@@ -1033,7 +1033,7 @@ if ( class_exists( 'GFForms' ) ) {
 		 * @return array Entry properties.
 		 */
 		public function maybe_update_payment_statuses( $properties, $form_id ) {
-			if ( gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $form_id ) ) {
+			if ( gravity_flow_woocommerce()->can_create_entry_for_order( $form_id ) ) {
 				$wc_order_statuses = $this->wc_order_statuses();
 
 				$properties['payment_status']['filter']['choices'] = $wc_order_statuses;
@@ -1053,7 +1053,7 @@ if ( class_exists( 'GFForms' ) ) {
 		 * @return array $field_filters
 		 */
 		public function filter_gform_field_filters( $field_filters, $form ) {
-			if ( gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $form['id'] ) ) {
+			if ( gravity_flow_woocommerce()->can_create_entry_for_order( $form['id'] ) ) {
 				$wc_order_statuses = $this->wc_order_statuses();
 
 				foreach ( $field_filters as $k => $field_filter ) {

--- a/class-woocommerce.php
+++ b/class-woocommerce.php
@@ -392,6 +392,13 @@ if ( class_exists( 'GFForms' ) ) {
 				$result = rgar( $settings, "payment_status_{$order->get_status()}" ) === '1' || ! isset( $settings[ "payment_status_{$order->get_status()}" ] );
 			}
 
+			/**
+			 * Filter custom payment statuses or add additional conditions.
+			 *
+			 * @param boolean $result True or false.
+			 * @param int     $form_id Form ID.
+			 * @param int     $order_id Order ID.
+			 */
 			return apply_filters( 'gravityflowwoocommerce_is_payment_status_enabled', $result, $form_id, $order_id );
 		}
 

--- a/class-woocommerce.php
+++ b/class-woocommerce.php
@@ -386,11 +386,13 @@ if ( class_exists( 'GFForms' ) ) {
 
 			$mode_value = rgar( $settings, 'payment_statuses_mode', 'all_payment_statuses' );
 			if ( $mode_value === 'all_payment_statuses' ) {
-				return true;
+				$result = true;
 			} else {
-				$order = wc_get_order( $order_id );
-				return rgar( $settings, "payment_status_{$order->get_status()}" ) === '1' || ! isset( $settings[ "payment_status_{$order->get_status()}" ] );
+				$order  = wc_get_order( $order_id );
+				$result = rgar( $settings, "payment_status_{$order->get_status()}" ) === '1' || ! isset( $settings[ "payment_status_{$order->get_status()}" ] );
 			}
+
+			return apply_filters( 'gravityflowwoocommerce_is_payment_status_enabled', $result, $form_id, $order_id );
 		}
 
 		/**

--- a/class-woocommerce.php
+++ b/class-woocommerce.php
@@ -373,8 +373,9 @@ if ( class_exists( 'GFForms' ) ) {
 			if ( $can_create ) {
 				$mode_value = rgar( $settings, 'payment_statuses_mode', 'all_payment_statuses' );
 				if ( ! is_null( $order_id ) ) {
+					$order = wc_get_order( $order_id );
+
 					if ( ! $mode_value === 'all_payment_statuses' ) {
-						$order      = wc_get_order( $order_id );
 						$can_create = rgar( $settings, "payment_status_{$order->get_status()}" ) === '1' || ! isset( $settings[ "payment_status_{$order->get_status()}" ] );
 					}
 
@@ -383,13 +384,13 @@ if ( class_exists( 'GFForms' ) ) {
 					 *
 					 * @since 1.1
 					 *
-					 * @param boolean $can_create If can create entry or not.
-					 * @param int     $form_id Form ID.
-					 * @param int     $order_id Order ID.
+					 * @param boolean  $can_create If can create entry or not.
+					 * @param int      $form_id Form ID.
+					 * @param WC_Order $order_id WC Order object.
 					 *
 					 * @return boolean True if can create entry, false otherwise.
 					 */
-					$can_create = apply_filters( 'gravityflowwoocommerce_can_create_entry', $can_create, $form_id, $order_id );
+					$can_create = apply_filters( 'gravityflowwoocommerce_can_create_entry', $can_create, $form_id, $order );
 				}
 			}
 

--- a/includes/class-wc-gateway-gravity-flow-pay-later.php
+++ b/includes/class-wc-gateway-gravity-flow-pay-later.php
@@ -173,10 +173,11 @@ class WC_Gateway_Gravity_Flow_Pay_Later extends WC_Payment_Gateway {
 		}
 
 		if ( $order->get_payment_method() === $this->id ) {
-			$entry_ids = get_post_meta( $order->get_id(), '_gravityflow-entry-id' );
+			$order_id  = $order->get_id();
+			$entry_ids = get_post_meta( $order_id, '_gravityflow-entry-id' );
 			foreach ( $entry_ids as $entry_id ) {
 				$entry = GFAPI::get_entry( $entry_id );
-				if ( is_wp_error( $entry ) || ! gravity_flow_woocommerce()->can_create_entry_for_order( $entry['form_id'] ) ) {
+				if ( is_wp_error( $entry ) || ! gravity_flow_woocommerce()->can_create_entry_for_order( $entry['form_id'], $order_id ) ) {
 					continue;
 				}
 
@@ -211,10 +212,11 @@ class WC_Gateway_Gravity_Flow_Pay_Later extends WC_Payment_Gateway {
 			if ( $order->get_payment_method() === $this->id ) {
 				$result = false;
 
-				$entry_ids = get_post_meta( $order->get_id(), '_gravityflow-entry-id' );
+				$order_id  = $order->get_id();
+				$entry_ids = get_post_meta( $order_id, '_gravityflow-entry-id' );
 				foreach ( $entry_ids as $entry_id ) {
 					$entry = GFAPI::get_entry( $entry_id );
-					if ( is_wp_error( $entry ) || ! gravity_flow_woocommerce()->can_create_entry_for_order( $entry['form_id'] ) ) {
+					if ( is_wp_error( $entry ) || ! gravity_flow_woocommerce()->can_create_entry_for_order( $entry['form_id'], $order_id ) ) {
 						continue;
 					}
 

--- a/includes/class-wc-gateway-gravity-flow-pay-later.php
+++ b/includes/class-wc-gateway-gravity-flow-pay-later.php
@@ -176,7 +176,7 @@ class WC_Gateway_Gravity_Flow_Pay_Later extends WC_Payment_Gateway {
 			$entry_ids = get_post_meta( $order->get_id(), '_gravityflow-entry-id' );
 			foreach ( $entry_ids as $entry_id ) {
 				$entry = GFAPI::get_entry( $entry_id );
-				if ( is_wp_error( $entry ) || ! gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $entry['form_id'] ) ) {
+				if ( is_wp_error( $entry ) || ! gravity_flow_woocommerce()->can_create_entry_for_order( $entry['form_id'] ) ) {
 					continue;
 				}
 
@@ -214,7 +214,7 @@ class WC_Gateway_Gravity_Flow_Pay_Later extends WC_Payment_Gateway {
 				$entry_ids = get_post_meta( $order->get_id(), '_gravityflow-entry-id' );
 				foreach ( $entry_ids as $entry_id ) {
 					$entry = GFAPI::get_entry( $entry_id );
-					if ( is_wp_error( $entry ) || ! gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $entry['form_id'] ) ) {
+					if ( is_wp_error( $entry ) || ! gravity_flow_woocommerce()->can_create_entry_for_order( $entry['form_id'] ) ) {
 						continue;
 					}
 

--- a/includes/steps/class-step-woocommerce-capture-payment.php
+++ b/includes/steps/class-step-woocommerce-capture-payment.php
@@ -53,7 +53,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) && function_exists( 'WC' ) ) {
 		public function is_supported() {
 			$form_id = $this->get_form_id();
 
-			return function_exists( 'WC' ) && gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $form_id );
+			return function_exists( 'WC' ) && gravity_flow_woocommerce()->can_create_entry_for_order( $form_id );
 		}
 
 		/**

--- a/includes/steps/class-step-woocommerce-checkout.php
+++ b/includes/steps/class-step-woocommerce-checkout.php
@@ -84,7 +84,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) && function_exists( 'WC' ) ) {
 		 * @return bool
 		 */
 		public function is_supported() {
-			return function_exists( 'WC' ) && ! gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $this->get_form_id() );
+			return function_exists( 'WC' ) && ! gravity_flow_woocommerce()->can_create_entry_for_order( $this->get_form_id() );
 		}
 
 		/**

--- a/includes/steps/class-step-woocommerce-payment.php
+++ b/includes/steps/class-step-woocommerce-payment.php
@@ -147,7 +147,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) && function_exists( 'WC' ) ) {
 
 					$assignees[] = new Gravity_Flow_Assignee( $assignee_key, $this );
 				}
-			} elseif ( ! gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $this->get_form_id() ) ) {
+			} elseif ( ! gravity_flow_woocommerce()->can_create_entry_for_order( $this->get_form_id() ) ) {
 				$assignees = parent::get_assignees();
 			}
 
@@ -187,7 +187,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) && function_exists( 'WC' ) ) {
 						$note = $this->get_name() . ': ' . esc_html__( 'Waiting for payment status to be updated.', 'gravityflowwoocommerce' );
                     }
 				} else {
-					if ( ! gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $this->get_form_id() ) ) {
+					if ( ! gravity_flow_woocommerce()->can_create_entry_for_order( $this->get_form_id() ) ) {
 						$this->assign();
 					}
 					$this->log_debug( __METHOD__ . '(): Started, waiting for the order id.' );

--- a/includes/steps/class-step-woocommerce-payment.php
+++ b/includes/steps/class-step-woocommerce-payment.php
@@ -147,7 +147,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) && function_exists( 'WC' ) ) {
 
 					$assignees[] = new Gravity_Flow_Assignee( $assignee_key, $this );
 				}
-			} elseif ( ! gravity_flow_woocommerce()->can_create_entry_for_order( $this->get_form_id() ) ) {
+			} elseif ( ! gravity_flow_woocommerce()->can_create_entry_for_order( $this->get_form_id(), $order_id ) ) {
 				$assignees = parent::get_assignees();
 			}
 
@@ -182,12 +182,12 @@ if ( class_exists( 'Gravity_Flow_Step' ) && function_exists( 'WC' ) ) {
 						$this->assign();
 						$this->log_debug( __METHOD__ . '(): Started, waiting for payment.' );
 						$note = $this->get_name() . ': ' . esc_html__( 'Waiting for payment.', 'gravityflowwoocommerce' );
-                    } else {
+					} else {
 						$this->log_debug( __METHOD__ . '(): Started, waiting for payment status to be updated.' );
 						$note = $this->get_name() . ': ' . esc_html__( 'Waiting for payment status to be updated.', 'gravityflowwoocommerce' );
-                    }
+					}
 				} else {
-					if ( ! gravity_flow_woocommerce()->can_create_entry_for_order( $this->get_form_id() ) ) {
+					if ( ! gravity_flow_woocommerce()->can_create_entry_for_order( $this->get_form_id(), $order->get_id() ) ) {
 						$this->assign();
 					}
 					$this->log_debug( __METHOD__ . '(): Started, waiting for the order id.' );

--- a/includes/steps/class-step-woocommerce-refund-order.php
+++ b/includes/steps/class-step-woocommerce-refund-order.php
@@ -44,7 +44,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) && function_exists( 'WC' ) ) {
 			$form_id = $this->get_form_id();
 			$form    = GFAPI::get_form( $form_id );
 
-			return function_exists( 'WC' ) && ( ! empty( GFFormsModel::get_fields_by_type( $form, 'workflow_woocommerce_order_id' ) ) || gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $form_id ) );
+			return function_exists( 'WC' ) && ( ! empty( GFFormsModel::get_fields_by_type( $form, 'workflow_woocommerce_order_id' ) ) || gravity_flow_woocommerce()->can_create_entry_for_order( $form_id ) );
 		}
 
 		/**
@@ -60,7 +60,7 @@ if ( class_exists( 'Gravity_Flow_Step' ) && function_exists( 'WC' ) ) {
 				'input_types' => array( 'workflow_woocommerce_order_id', 'hidden', 'text' ),
 			);
 
-			if ( gravity_flow_woocommerce()->is_woocommerce_orders_integration_enabled( $form['id'] ) ) {
+			if ( gravity_flow_woocommerce()->can_create_entry_for_order( $form['id'] ) ) {
 				$args['append_choices'] = array(
 					array(
 						'label' => esc_html__( 'Current Entry: WooCommerce Order ID', 'gravityflowwoocommerce' ),


### PR DESCRIPTION
re: [HS#7195](https://secure.helpscout.net/conversation/711427960/7195?folderId=2308453)

This PR adds a new filter `gravityflowwoocommerce_can_create_entry` on top of the "Create Entries on Specific Statuses" setting, so it can be more flexible to decide if new entries should be created (based on Order contents etc.).

This can also help us to filter out renewal orders from WooCommerce Subscriptions. See this gist on how to prevent new entries from being created by renewal orders: https://gist.github.com/yoren/5c18207d5854ca68d03665113f31220b.

**Testing instructions**
1. Purchase this subscription item: http://dev-wcgflow.pantheonsite.io/product/subscription/
2. I have added the filter to the website http://dev-wcgflow.pantheonsite.io/wp-admin/plugin-editor.php?file=theme-customisations-master%2Fcustom%2Ffunctions.php&plugin=theme-customisations-master%2Ftheme-customisations.php, so renewal orders will be skipped (for all forms that enable Create Entries).
3. Go to the WP dashboard, on "WooCommerce - Subscriptions", find the latest subscription and click to edit it. On the right side of the edit screen, select "Process renewal" (https://www.dropbox.com/s/rz3luwtxoh6qzos/Screenshot%202018-12-27%2018.09.54.png?dl=0). You should see two new orders in your WooCommerce Orders as of now.
4. Check the Entries http://dev-wcgflow.pantheonsite.io/wp-admin/admin.php?page=gf_entries&id=4, you'll see only one new entry from the order started the subscription, but not the renewal one.